### PR TITLE
Normalize unicode out of folder names

### DIFF
--- a/chameleon-server/src/main/java/com/chameleonvision/vision/VisionManager.java
+++ b/chameleon-server/src/main/java/com/chameleonvision/vision/VisionManager.java
@@ -44,7 +44,8 @@ public class VisionManager {
             VideoCapture cap = new VideoCapture(info.dev);
             if (cap.isOpened()) {
                 cap.release();
-                String name = info.name;
+                // Filter non-ascii characters because ext4 doesn't play nice with unicode in directory names
+                String name = info.name.replaceAll("[^\\x00-\\x7F]", "");
                 while (usbCameraInfosByCameraName.containsKey(name)) {
                     suffix++;
                     name = String.format("%s (%d)", name, suffix);


### PR DESCRIPTION
Some filesystems (e.g. ext4) will not allow unicode characters to be part of directory names. Change VisionManager to filter all non-ascii out of the camera name to ensure this doesn't crash the server.