### PR TITLE
Support running on OSX for development

### DIFF
--- a/chameleon-server/src/main/java/com/chameleonvision/network/NetworkManager.java
+++ b/chameleon-server/src/main/java/com/chameleonvision/network/NetworkManager.java
@@ -1,12 +1,12 @@
 package com.chameleonvision.network;
 
 
-import com.chameleonvision.config.ConfigManager;
-import com.chameleonvision.util.Platform;
-
 import java.net.SocketException;
 import java.util.ArrayList;
 import java.util.List;
+
+import com.chameleonvision.config.ConfigManager;
+import com.chameleonvision.util.Platform;
 
 public class NetworkManager {
     private NetworkManager() {
@@ -25,14 +25,11 @@ public class NetworkManager {
 
         if (platform.isLinux()) {
             networking = new LinuxNetworking();
-        } else if (platform.isWindows()) {
-//			networking = new WindowsNetworking();
-            System.out.println("Windows networking is not yet supported. Running unmanaged.");
-            return;
-        }
+        } 
 
         if (networking == null) {
-            throw new RuntimeException("Failed to detect platform!");
+            System.out.println("This platform does not support managed networking, so will not try.");
+            return;
         }
 
         List<java.net.NetworkInterface> interfaces = new ArrayList<>();

--- a/chameleon-server/src/main/java/com/chameleonvision/util/Platform.java
+++ b/chameleon-server/src/main/java/com/chameleonvision/util/Platform.java
@@ -85,7 +85,7 @@ public enum Platform {
 		}
 
 		if (OS_NAME.contains("Mac")) {
-			if (OS_ARCH.equals("amd64")) return Platform.MACOS_64;
+			if (OS_ARCH.equals("amd64") || OS_ARCH.equals("x86_64")) return Platform.MACOS_64;
 		}
 
 		System.out.printf("Unknown Platform! OS: %s, Architecture: %s", OS_NAME, OS_ARCH);


### PR DESCRIPTION
To get this to start on my 2017 MBP running Mojave, I needed to
recognize x86_64 hardware and tell it to not have managed networking. I
suppose the latter is a command line option, but there was a case for
Windows being able to continue without using it so I went with that
convention.

```
$ uname -a
Darwin seans-mbp-3.lan 18.7.0 Darwin Kernel Version 18.7.0: Thu Jan 23 06:52:12 PST 2020; root:xnu-4903.278.25~1/RELEASE_X86_64 x86_64
```