### PR TITLE
Fail quickly if essential items don't work

### DIFF
--- a/chameleon-server/src/main/java/com/chameleonvision/Main.java
+++ b/chameleon-server/src/main/java/com/chameleonvision/Main.java
@@ -160,16 +160,20 @@ public class Main {
 
         ScriptManager.queueEvent(ScriptEventType.kProgramInit);
 
-        boolean visionSourcesOk = VisionManager.initializeSources();
-        if (!visionSourcesOk) {
-            System.err.println("No cameras connected!");
-            return;
+        try {
+            if (! VisionManager.initializeSources()) {
+                System.err.println("No cameras connected!");
+                Runtime.getRuntime().exit(1);
+            }
+        } catch (RuntimeException e) {
+            System.err.println("Error trying to enumerate cameras. Do you have a USB camera connected?");
+            Runtime.getRuntime().exit(1);
         }
 
         boolean visionProcessesOk = VisionManager.initializeProcesses();
         if (!visionProcessesOk) {
             System.err.println("Failed to initialize vision processes!");
-            return;
+            Runtime.getRuntime().exit(1);
         }
 
         System.out.println("Starting vision processes...");


### PR DESCRIPTION
There are some cases where Main calls `return`, presumably with the
intention of exiting, but due to the NT and ScriptRunner threads
running, the program will never exit. Also, at least on my machine,
having no USB cameras throws an exception that's not caught, leaving the
app in limbo.

This change forces all threads to stop if no cameras or vision pipelines
can be instantiated. This will let the supervisor (e.g. systemd) restart
the app to handle conditions like cameras being unplugged prior to the
boot.

During our season we found that moving the camera port would cause this
exception because the USB ID changed. We would have to then go hard
cycle the Pi, when it would have been much easier to just move the port
and know that CV would restart shortly.